### PR TITLE
net-tcp_bbr: v3: use correct 64-bit division

### DIFF
--- a/net/ipv4/tcp_bbr.c
+++ b/net/ipv4/tcp_bbr.c
@@ -497,7 +497,7 @@ static u32 bbr_tso_segs_generic(struct sock *sk, unsigned int mss_now,
 	}
 
 	bytes = min_t(u32, bytes, gso_max_size - 1 - MAX_TCP_HEADER);
-	segs = max_t(u32, bytes / mss_now,
+	segs = max_t(u32, div_u64(bytes, mss_now),
 		     sock_net(sk)->ipv4.sysctl_tcp_min_tso_segs);
 	return segs;
 }


### PR DESCRIPTION
This commit addresses an issue with integer division on 32-bit system builds, which resulted in undefined symbol errors during the build process.

Errors observed:

arm:
ERROR: modpost: "__aeabi_uldivmod" [net/ipv4/tcp_bbr.ko] undefined! ERROR: modpost: "__aeabi_ldivmod" [net/ipv4/tcp_bbr.ko] undefined!

x86, mips, ppc:
ERROR: modpost: "__udivdi3" [net/ipv4/tcp_bbr.ko] undefined! ERROR: modpost: "__divdi3" [net/ipv4/tcp_bbr.ko] undefined!

The fix ensures proper 64-bit division on affected architectures.